### PR TITLE
Microservices consistent logging

### DIFF
--- a/microservices/go-service/Gopkg.lock
+++ b/microservices/go-service/Gopkg.lock
@@ -15,7 +15,7 @@
 
 [[projects]]
   name = "github.com/go-kit/kit"
-  packages = ["log"]
+  packages = ["log","log/level"]
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
@@ -118,6 +118,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "31308007de4e398a633c52b76466c12191e75489d8cef1ea90a72e7cf3f7b41c"
+  inputs-digest = "3fc9a19d47f997eb4db6738a3344ff2a5bcc7fafe5baca14ddfdd2944bf62715"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/microservices/go-service/config/config.go
+++ b/microservices/go-service/config/config.go
@@ -6,12 +6,16 @@ import (
 )
 
 const (
+	defaultLogLevel    = "info"
+	defaultServiceName = "go-service"
 	defaultServicePort = ":4010"
 	defaultRedisURL    = "redis://localhost:6379"
 )
 
 // Config represents configurations of service
 type Config struct {
+	LogLevel    string
+	ServiceName string
 	ServicePort string
 	RedisURL    string
 }
@@ -39,6 +43,8 @@ func getValue(name, defaultValue string) string {
 // GetConfig retrieves configuratinos
 func GetConfig() Config {
 	return Config{
+		LogLevel:    getValue("LOG_LEVEL", defaultLogLevel),
+		ServiceName: getValue("SERVICE_NAME", defaultServiceName),
 		ServicePort: getValue("SERVICE_PORT", defaultServicePort),
 		RedisURL:    getValue("REDIS_URL", defaultRedisURL),
 	}

--- a/microservices/go-service/config/config_test.go
+++ b/microservices/go-service/config/config_test.go
@@ -71,6 +71,9 @@ func TestGetValue(t *testing.T) {
 
 func TestGetConfig(t *testing.T) {
 	config := GetConfig()
+
+	assert.Equal(t, defaultLogLevel, config.LogLevel)
+	assert.Equal(t, defaultServiceName, config.ServiceName)
 	assert.Equal(t, defaultServicePort, config.ServicePort)
 	assert.Equal(t, defaultRedisURL, config.RedisURL)
 }

--- a/microservices/go-service/docker-compose.yml
+++ b/microservices/go-service/docker-compose.yml
@@ -16,4 +16,5 @@ services:
     ports:
       - "4010:4010"
     environment:
+      - LOG_LEVEL=debug
       - REDIS_URL=redis://redis:6379

--- a/microservices/go-service/handler/common.go
+++ b/microservices/go-service/handler/common.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
 )
 
 // HealthHandler is the http handler for health requests
@@ -25,7 +26,7 @@ func GetNotFoundHandler(logger log.Logger) http.HandlerFunc {
 
 		err := json.NewEncoder(w).Encode(body)
 		if err != nil && logger != nil {
-			logger.Log("message", "Error sending not found (404)")
+			level.Error(logger).Log("message", "Error sending not found (404)")
 		}
 	}
 }

--- a/microservices/go-service/middleware/middleware_test.go
+++ b/microservices/go-service/middleware/middleware_test.go
@@ -46,7 +46,7 @@ func TestWrapAll(t *testing.T) {
 			handler(w, r)
 			res := w.Result()
 
-			assert.Equal(t, res.StatusCode, http.StatusNotFound)
+			assert.Equal(t, http.StatusNotFound, res.StatusCode)
 			for _, m := range tc.middleware {
 				mock, ok := m.(*mockMiddleware)
 				assert.True(t, ok)

--- a/microservices/go-service/server/server_test.go
+++ b/microservices/go-service/server/server_test.go
@@ -28,21 +28,69 @@ func (s *mockServer) Shutdown(context.Context) error {
 	return s.ShutdownError
 }
 
+func TestNewLogger(t *testing.T) {
+	tests := []struct {
+		name   string
+		config config.Config
+	}{
+		{
+			"Debug",
+			config.Config{
+				LogLevel:    "debug",
+				ServiceName: "job-service",
+			},
+		},
+		{
+			"Info",
+			config.Config{
+				LogLevel:    "info",
+				ServiceName: "auth-service",
+			},
+		},
+		{
+			"Warn",
+			config.Config{
+				LogLevel:    "warn",
+				ServiceName: "gateway-service",
+			},
+		},
+		{
+			"Error",
+			config.Config{
+				LogLevel:    "error",
+				ServiceName: "storage-service",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := newLogger(tc.config)
+
+			assert.NotNil(t, logger)
+		})
+	}
+}
+
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name   string
 		config config.Config
 	}{
 		{
-			"No.1",
+			"Server1",
 			config.Config{
+				LogLevel:    "info",
+				ServiceName: "go-service",
 				ServicePort: ":4010",
 				RedisURL:    "redis://redis:6379",
 			},
 		},
 		{
-			"No.2",
+			"Server2",
 			config.Config{
+				LogLevel:    "debug",
+				ServiceName: "golang-service",
 				ServicePort: ":4020",
 				RedisURL:    "redis://user:pass@redis:6389",
 			},

--- a/microservices/go-service/vendor/github.com/go-kit/kit/log/level/benchmark_test.go
+++ b/microservices/go-service/vendor/github.com/go-kit/kit/log/level/benchmark_test.go
@@ -1,0 +1,72 @@
+package level_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+func Benchmark(b *testing.B) {
+	contexts := []struct {
+		name    string
+		context func(log.Logger) log.Logger
+	}{
+		{"NoContext", func(l log.Logger) log.Logger {
+			return l
+		}},
+		{"TimeContext", func(l log.Logger) log.Logger {
+			return log.With(l, "time", log.DefaultTimestampUTC)
+		}},
+		{"CallerContext", func(l log.Logger) log.Logger {
+			return log.With(l, "caller", log.DefaultCaller)
+		}},
+		{"TimeCallerReqIDContext", func(l log.Logger) log.Logger {
+			return log.With(l, "time", log.DefaultTimestampUTC, "caller", log.DefaultCaller, "reqID", 29)
+		}},
+	}
+
+	loggers := []struct {
+		name   string
+		logger log.Logger
+	}{
+		{"Nop", log.NewNopLogger()},
+		{"Logfmt", log.NewLogfmtLogger(ioutil.Discard)},
+		{"JSON", log.NewJSONLogger(ioutil.Discard)},
+	}
+
+	filters := []struct {
+		name   string
+		filter func(log.Logger) log.Logger
+	}{
+		{"Baseline", func(l log.Logger) log.Logger {
+			return l
+		}},
+		{"DisallowedLevel", func(l log.Logger) log.Logger {
+			return level.NewFilter(l, level.AllowInfo())
+		}},
+		{"AllowedLevel", func(l log.Logger) log.Logger {
+			return level.NewFilter(l, level.AllowAll())
+		}},
+	}
+
+	for _, c := range contexts {
+		b.Run(c.name, func(b *testing.B) {
+			for _, f := range filters {
+				b.Run(f.name, func(b *testing.B) {
+					for _, l := range loggers {
+						b.Run(l.name, func(b *testing.B) {
+							logger := c.context(f.filter(l.logger))
+							b.ResetTimer()
+							b.ReportAllocs()
+							for i := 0; i < b.N; i++ {
+								level.Debug(logger).Log("foo", "bar")
+							}
+						})
+					}
+				})
+			}
+		})
+	}
+}

--- a/microservices/go-service/vendor/github.com/go-kit/kit/log/level/doc.go
+++ b/microservices/go-service/vendor/github.com/go-kit/kit/log/level/doc.go
@@ -1,0 +1,22 @@
+// Package level implements leveled logging on top of package log. To use the
+// level package, create a logger as per normal in your func main, and wrap it
+// with level.NewFilter.
+//
+//    var logger log.Logger
+//    logger = log.NewLogfmtLogger(os.Stderr)
+//    logger = level.NewFilter(logger, level.AllowInfoAndAbove()) // <--
+//    logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+//
+// Then, at the callsites, use one of the level.Debug, Info, Warn, or Error
+// helper methods to emit leveled log events.
+//
+//    logger.Log("foo", "bar") // as normal, no level
+//    level.Debug(logger).Log("request_id", reqID, "trace_data", trace.Get())
+//    if value > 100 {
+//        level.Error(logger).Log("value", value)
+//    }
+//
+// NewFilter allows precise control over what happens when a log event is
+// emitted without a level key, or if a squelched level is used. Check the
+// Option functions for details.
+package level

--- a/microservices/go-service/vendor/github.com/go-kit/kit/log/level/example_test.go
+++ b/microservices/go-service/vendor/github.com/go-kit/kit/log/level/example_test.go
@@ -1,0 +1,25 @@
+package level_test
+
+import (
+	"errors"
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+func Example_basic() {
+	// setup logger with level filter
+	logger := log.NewLogfmtLogger(os.Stdout)
+	logger = level.NewFilter(logger, level.AllowInfo())
+	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	// use level helpers to log at different levels
+	level.Error(logger).Log("err", errors.New("bad data"))
+	level.Info(logger).Log("event", "data saved")
+	level.Debug(logger).Log("next item", 17) // filtered
+
+	// Output:
+	// level=error caller=example_test.go:18 err="bad data"
+	// level=info caller=example_test.go:19 event="data saved"
+}

--- a/microservices/go-service/vendor/github.com/go-kit/kit/log/level/level.go
+++ b/microservices/go-service/vendor/github.com/go-kit/kit/log/level/level.go
@@ -1,0 +1,205 @@
+package level
+
+import "github.com/go-kit/kit/log"
+
+// Error returns a logger that includes a Key/ErrorValue pair.
+func Error(logger log.Logger) log.Logger {
+	return log.WithPrefix(logger, Key(), ErrorValue())
+}
+
+// Warn returns a logger that includes a Key/WarnValue pair.
+func Warn(logger log.Logger) log.Logger {
+	return log.WithPrefix(logger, Key(), WarnValue())
+}
+
+// Info returns a logger that includes a Key/InfoValue pair.
+func Info(logger log.Logger) log.Logger {
+	return log.WithPrefix(logger, Key(), InfoValue())
+}
+
+// Debug returns a logger that includes a Key/DebugValue pair.
+func Debug(logger log.Logger) log.Logger {
+	return log.WithPrefix(logger, Key(), DebugValue())
+}
+
+// NewFilter wraps next and implements level filtering. See the commentary on
+// the Option functions for a detailed description of how to configure levels.
+// If no options are provided, all leveled log events created with Debug,
+// Info, Warn or Error helper methods are squelched and non-leveled log
+// events are passed to next unmodified.
+func NewFilter(next log.Logger, options ...Option) log.Logger {
+	l := &logger{
+		next: next,
+	}
+	for _, option := range options {
+		option(l)
+	}
+	return l
+}
+
+type logger struct {
+	next           log.Logger
+	allowed        level
+	squelchNoLevel bool
+	errNotAllowed  error
+	errNoLevel     error
+}
+
+func (l *logger) Log(keyvals ...interface{}) error {
+	var hasLevel, levelAllowed bool
+	for i := 1; i < len(keyvals); i += 2 {
+		if v, ok := keyvals[i].(*levelValue); ok {
+			hasLevel = true
+			levelAllowed = l.allowed&v.level != 0
+			break
+		}
+	}
+	if !hasLevel && l.squelchNoLevel {
+		return l.errNoLevel
+	}
+	if hasLevel && !levelAllowed {
+		return l.errNotAllowed
+	}
+	return l.next.Log(keyvals...)
+}
+
+// Option sets a parameter for the leveled logger.
+type Option func(*logger)
+
+// AllowAll is an alias for AllowDebug.
+func AllowAll() Option {
+	return AllowDebug()
+}
+
+// AllowDebug allows error, warn, info and debug level log events to pass.
+func AllowDebug() Option {
+	return allowed(levelError | levelWarn | levelInfo | levelDebug)
+}
+
+// AllowInfo allows error, warn and info level log events to pass.
+func AllowInfo() Option {
+	return allowed(levelError | levelWarn | levelInfo)
+}
+
+// AllowWarn allows error and warn level log events to pass.
+func AllowWarn() Option {
+	return allowed(levelError | levelWarn)
+}
+
+// AllowError allows only error level log events to pass.
+func AllowError() Option {
+	return allowed(levelError)
+}
+
+// AllowNone allows no leveled log events to pass.
+func AllowNone() Option {
+	return allowed(0)
+}
+
+func allowed(allowed level) Option {
+	return func(l *logger) { l.allowed = allowed }
+}
+
+// ErrNotAllowed sets the error to return from Log when it squelches a log
+// event disallowed by the configured Allow[Level] option. By default,
+// ErrNotAllowed is nil; in this case the log event is squelched with no
+// error.
+func ErrNotAllowed(err error) Option {
+	return func(l *logger) { l.errNotAllowed = err }
+}
+
+// SquelchNoLevel instructs Log to squelch log events with no level, so that
+// they don't proceed through to the wrapped logger. If SquelchNoLevel is set
+// to true and a log event is squelched in this way, the error value
+// configured with ErrNoLevel is returned to the caller.
+func SquelchNoLevel(squelch bool) Option {
+	return func(l *logger) { l.squelchNoLevel = squelch }
+}
+
+// ErrNoLevel sets the error to return from Log when it squelches a log event
+// with no level. By default, ErrNoLevel is nil; in this case the log event is
+// squelched with no error.
+func ErrNoLevel(err error) Option {
+	return func(l *logger) { l.errNoLevel = err }
+}
+
+// NewInjector wraps next and returns a logger that adds a Key/level pair to
+// the beginning of log events that don't already contain a level. In effect,
+// this gives a default level to logs without a level.
+func NewInjector(next log.Logger, level Value) log.Logger {
+	return &injector{
+		next:  next,
+		level: level,
+	}
+}
+
+type injector struct {
+	next  log.Logger
+	level interface{}
+}
+
+func (l *injector) Log(keyvals ...interface{}) error {
+	for i := 1; i < len(keyvals); i += 2 {
+		if _, ok := keyvals[i].(*levelValue); ok {
+			return l.next.Log(keyvals...)
+		}
+	}
+	kvs := make([]interface{}, len(keyvals)+2)
+	kvs[0], kvs[1] = key, l.level
+	copy(kvs[2:], keyvals)
+	return l.next.Log(kvs...)
+}
+
+// Value is the interface that each of the canonical level values implement.
+// It contains unexported methods that prevent types from other packages from
+// implementing it and guaranteeing that NewFilter can distinguish the levels
+// defined in this package from all other values.
+type Value interface {
+	String() string
+	levelVal()
+}
+
+// Key returns the unique key added to log events by the loggers in this
+// package.
+func Key() interface{} { return key }
+
+// ErrorValue returns the unique value added to log events by Error.
+func ErrorValue() Value { return errorValue }
+
+// WarnValue returns the unique value added to log events by Warn.
+func WarnValue() Value { return warnValue }
+
+// InfoValue returns the unique value added to log events by Info.
+func InfoValue() Value { return infoValue }
+
+// DebugValue returns the unique value added to log events by Warn.
+func DebugValue() Value { return debugValue }
+
+var (
+	// key is of type interfae{} so that it allocates once during package
+	// initialization and avoids allocating every type the value is added to a
+	// []interface{} later.
+	key interface{} = "level"
+
+	errorValue = &levelValue{level: levelError, name: "error"}
+	warnValue  = &levelValue{level: levelWarn, name: "warn"}
+	infoValue  = &levelValue{level: levelInfo, name: "info"}
+	debugValue = &levelValue{level: levelDebug, name: "debug"}
+)
+
+type level byte
+
+const (
+	levelDebug level = 1 << iota
+	levelInfo
+	levelWarn
+	levelError
+)
+
+type levelValue struct {
+	name string
+	level
+}
+
+func (v *levelValue) String() string { return v.name }
+func (v *levelValue) levelVal()      {}

--- a/microservices/go-service/vendor/github.com/go-kit/kit/log/level/level_test.go
+++ b/microservices/go-service/vendor/github.com/go-kit/kit/log/level/level_test.go
@@ -1,0 +1,235 @@
+package level_test
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+func TestVariousLevels(t *testing.T) {
+	testCases := []struct {
+		name    string
+		allowed level.Option
+		want    string
+	}{
+		{
+			"AllowAll",
+			level.AllowAll(),
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"AllowDebug",
+			level.AllowDebug(),
+			strings.Join([]string{
+				`{"level":"debug","this is":"debug log"}`,
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"AllowInfo",
+			level.AllowInfo(),
+			strings.Join([]string{
+				`{"level":"info","this is":"info log"}`,
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"AllowWarn",
+			level.AllowWarn(),
+			strings.Join([]string{
+				`{"level":"warn","this is":"warn log"}`,
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"AllowError",
+			level.AllowError(),
+			strings.Join([]string{
+				`{"level":"error","this is":"error log"}`,
+			}, "\n"),
+		},
+		{
+			"AllowNone",
+			level.AllowNone(),
+			``,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := level.NewFilter(log.NewJSONLogger(&buf), tc.allowed)
+
+			level.Debug(logger).Log("this is", "debug log")
+			level.Info(logger).Log("this is", "info log")
+			level.Warn(logger).Log("this is", "warn log")
+			level.Error(logger).Log("this is", "error log")
+
+			if want, have := tc.want, strings.TrimSpace(buf.String()); want != have {
+				t.Errorf("\nwant:\n%s\nhave:\n%s", want, have)
+			}
+		})
+	}
+}
+
+func TestErrNotAllowed(t *testing.T) {
+	myError := errors.New("squelched!")
+	opts := []level.Option{
+		level.AllowWarn(),
+		level.ErrNotAllowed(myError),
+	}
+	logger := level.NewFilter(log.NewNopLogger(), opts...)
+
+	if want, have := myError, level.Info(logger).Log("foo", "bar"); want != have {
+		t.Errorf("want %#+v, have %#+v", want, have)
+	}
+
+	if want, have := error(nil), level.Warn(logger).Log("foo", "bar"); want != have {
+		t.Errorf("want %#+v, have %#+v", want, have)
+	}
+}
+
+func TestErrNoLevel(t *testing.T) {
+	myError := errors.New("no level specified")
+
+	var buf bytes.Buffer
+	opts := []level.Option{
+		level.SquelchNoLevel(true),
+		level.ErrNoLevel(myError),
+	}
+	logger := level.NewFilter(log.NewJSONLogger(&buf), opts...)
+
+	if want, have := myError, logger.Log("foo", "bar"); want != have {
+		t.Errorf("want %v, have %v", want, have)
+	}
+	if want, have := ``, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+}
+
+func TestAllowNoLevel(t *testing.T) {
+	var buf bytes.Buffer
+	opts := []level.Option{
+		level.SquelchNoLevel(false),
+		level.ErrNoLevel(errors.New("I should never be returned!")),
+	}
+	logger := level.NewFilter(log.NewJSONLogger(&buf), opts...)
+
+	if want, have := error(nil), logger.Log("foo", "bar"); want != have {
+		t.Errorf("want %v, have %v", want, have)
+	}
+	if want, have := `{"foo":"bar"}`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+}
+
+func TestLevelContext(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Wrapping the level logger with a context allows users to use
+	// log.DefaultCaller as per normal.
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	logger = level.NewFilter(logger, level.AllowAll())
+	logger = log.With(logger, "caller", log.DefaultCaller)
+
+	level.Info(logger).Log("foo", "bar")
+	if want, have := `level=info caller=level_test.go:149 foo=bar`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+}
+
+func TestContextLevel(t *testing.T) {
+	var buf bytes.Buffer
+
+	// Wrapping a context with the level logger still works, but requires users
+	// to specify a higher callstack depth value.
+	var logger log.Logger
+	logger = log.NewLogfmtLogger(&buf)
+	logger = log.With(logger, "caller", log.Caller(5))
+	logger = level.NewFilter(logger, level.AllowAll())
+
+	level.Info(logger).Log("foo", "bar")
+	if want, have := `caller=level_test.go:165 level=info foo=bar`, strings.TrimSpace(buf.String()); want != have {
+		t.Errorf("\nwant '%s'\nhave '%s'", want, have)
+	}
+}
+
+func TestLevelFormatting(t *testing.T) {
+	testCases := []struct {
+		name   string
+		format func(io.Writer) log.Logger
+		output string
+	}{
+		{
+			name:   "logfmt",
+			format: log.NewLogfmtLogger,
+			output: `level=info foo=bar`,
+		},
+		{
+			name:   "JSON",
+			format: log.NewJSONLogger,
+			output: `{"foo":"bar","level":"info"}`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+
+			logger := tc.format(&buf)
+			level.Info(logger).Log("foo", "bar")
+			if want, have := tc.output, strings.TrimSpace(buf.String()); want != have {
+				t.Errorf("\nwant: '%s'\nhave '%s'", want, have)
+			}
+		})
+	}
+}
+
+func TestInjector(t *testing.T) {
+	var (
+		output []interface{}
+		logger log.Logger
+	)
+
+	logger = log.LoggerFunc(func(keyvals ...interface{}) error {
+		output = keyvals
+		return nil
+	})
+	logger = level.NewInjector(logger, level.InfoValue())
+
+	logger.Log("foo", "bar")
+	if got, want := len(output), 4; got != want {
+		t.Errorf("missing level not injected: got len==%d, want len==%d", got, want)
+	}
+	if got, want := output[0], level.Key(); got != want {
+		t.Errorf("wrong level key: got %#v, want %#v", got, want)
+	}
+	if got, want := output[1], level.InfoValue(); got != want {
+		t.Errorf("wrong level value: got %#v, want %#v", got, want)
+	}
+
+	level.Error(logger).Log("foo", "bar")
+	if got, want := len(output), 4; got != want {
+		t.Errorf("leveled record modified: got len==%d, want len==%d", got, want)
+	}
+	if got, want := output[0], level.Key(); got != want {
+		t.Errorf("wrong level key: got %#v, want %#v", got, want)
+	}
+	if got, want := output[1], level.ErrorValue(); got != want {
+		t.Errorf("wrong level value: got %#v, want %#v", got, want)
+	}
+}

--- a/microservices/node-service/middleware/logger.js
+++ b/microservices/node-service/middleware/logger.js
@@ -19,12 +19,15 @@ module.exports = {
   http (options) {
     options = options || {}
     options.winston = options.winston || Logger.getWinstonLogger()
+    let context = Object.assign({}, Logger.context, { logger: 'HttpMiddleware' })
 
     let loggerMiddleware = expressWinston.logger({
       winstonInstance: options.winston,
+      expressFormat: process.env.NODE_ENV === 'development',
 
       statusLevels: true,
-      expressFormat: process.env.NODE_ENV === 'development',
+      meta: true,
+      baseMeta: context,
 
       skip: options.skip || defaultSkip,
       ignoreRoute: options.ignoreRoute || defaultIgnoreRoute,

--- a/microservices/node-service/package.json
+++ b/microservices/node-service/package.json
@@ -19,7 +19,7 @@
     "express": "^4.16.2",
     "express-winston": "^2.4.0",
     "lodash": "^4.17.4",
-    "mongoose": "^5.0.0",
+    "mongoose": "^5.0.1",
     "on-finished": "^2.3.0",
     "prom-client": "^10.2.2",
     "request": "^2.83.0",
@@ -28,11 +28,11 @@
   },
   "devDependencies": {
     "istanbul": "^1.1.0-alpha.1",
-    "mocha": "^4.1.0",
+    "mocha": "^5.0.0",
     "nsp": "^3.1.0",
     "should": "^13.2.1",
     "should-http": "^0.1.1",
-    "sinon": "^4.1.5",
+    "sinon": "^4.1.6",
     "standard": "^10.0.3",
     "supertest": "^3.0.0",
     "tmp": "^0.0.33"

--- a/microservices/node-service/util/logger.js
+++ b/microservices/node-service/util/logger.js
@@ -5,16 +5,14 @@ const LOG_LEVELS = { fatal: 0, error: 1, warn: 2, info: 3, debug: 4, trace: 5 }
 
 /**
  * options:
- *   - level: trace|debug|info|warn|error|fatal
- *   - transports: [ ... ]
  *   - context: { ... }
  *   - winston: a winston logger instance
  */
 class Logger {
-  constructor (name, options) {
+  constructor (logger, options) {
     options = options || {}
     this.winston = options.winston || Logger.getWinstonLogger()
-    this.context = Object.assign({ pid: process.pid }, Logger.context, options.context, name ? { name } : {})
+    this.context = Object.assign({ pid: process.pid }, Logger.context, options.context, logger ? { logger } : {})
   }
 
   _log (level, args) {


### PR DESCRIPTION
This PR refactors logging codes in `go-service` and `node-service` to make them more consistent.

  - [x] Add `level` to `go-service` logs
  - [x] Add `service` and `logger` to `go-service` logger as `context`
  - [x] Log `service` and `logger` in http middleware for `node-service`