### PR TITLE
Microservices: add timestamp to go-service logs

### DIFF
--- a/microservices/go-service/server/server.go
+++ b/microservices/go-service/server/server.go
@@ -3,10 +3,8 @@ package server
 import (
 	"context"
 	"net/http"
-	"os"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
 	"github.com/gorilla/mux"
 	"github.com/moorara/toys/microservices/go-service/config"
 	"github.com/moorara/toys/microservices/go-service/handler"
@@ -30,29 +28,10 @@ type (
 	}
 )
 
-func newLogger(config config.Config) log.Logger {
-	logger := log.NewJSONLogger(os.Stdout)
-	logger = log.With(logger, "service", config.ServiceName, "logger", "GoKit")
-	logger = level.NewInjector(logger, level.InfoValue()) // default level
-
-	switch config.LogLevel {
-	case "debug":
-		logger = level.NewFilter(logger, level.AllowDebug())
-	case "info":
-		logger = level.NewFilter(logger, level.AllowInfo())
-	case "warn":
-		logger = level.NewFilter(logger, level.AllowWarn())
-	case "error":
-		logger = level.NewFilter(logger, level.AllowError())
-	}
-
-	return logger
-}
-
 // New creates a new http server
 func New(config config.Config) *HTTPServer {
 	metrics := util.NewMetrics("go_service")
-	logger := newLogger(config)
+	logger := util.NewLogger(config.LogLevel, config.ServiceName, "go-kit")
 
 	metricsMiddleware := middleware.NewMetricsMiddleware(metrics)
 	loggerMiddleware := middleware.NewLoggerMiddleware(logger)

--- a/microservices/go-service/server/server_test.go
+++ b/microservices/go-service/server/server_test.go
@@ -28,50 +28,6 @@ func (s *mockServer) Shutdown(context.Context) error {
 	return s.ShutdownError
 }
 
-func TestNewLogger(t *testing.T) {
-	tests := []struct {
-		name   string
-		config config.Config
-	}{
-		{
-			"Debug",
-			config.Config{
-				LogLevel:    "debug",
-				ServiceName: "job-service",
-			},
-		},
-		{
-			"Info",
-			config.Config{
-				LogLevel:    "info",
-				ServiceName: "auth-service",
-			},
-		},
-		{
-			"Warn",
-			config.Config{
-				LogLevel:    "warn",
-				ServiceName: "gateway-service",
-			},
-		},
-		{
-			"Error",
-			config.Config{
-				LogLevel:    "error",
-				ServiceName: "storage-service",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			logger := newLogger(tc.config)
-
-			assert.NotNil(t, logger)
-		})
-	}
-}
-
 func TestNew(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/microservices/go-service/util/logger.go
+++ b/microservices/go-service/util/logger.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"os"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// NewLogger creates a new logger based on go-kit logger
+func NewLogger(logLevel, serviceName, loggerName string) log.Logger {
+	logger := log.NewJSONLogger(os.Stdout)
+	logger = level.NewInjector(logger, level.InfoValue()) // default level
+	logger = log.With(
+		logger,
+		"timestamp", log.DefaultTimestampUTC,
+		"service", serviceName,
+		"logger", loggerName,
+	)
+
+	switch logLevel {
+	case "debug":
+		logger = level.NewFilter(logger, level.AllowDebug())
+	case "info":
+		logger = level.NewFilter(logger, level.AllowInfo())
+	case "warn":
+		logger = level.NewFilter(logger, level.AllowWarn())
+	case "error":
+		logger = level.NewFilter(logger, level.AllowError())
+	}
+
+	return logger
+}

--- a/microservices/go-service/util/logger_test.go
+++ b/microservices/go-service/util/logger_test.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLogger(t *testing.T) {
+	tests := []struct {
+		name        string
+		logLevel    string
+		serviceName string
+		loggerName  string
+	}{
+		{
+			"Debug", "debug", "job-service", "go-kit",
+		},
+		{
+			"Info", "info", "auth-service", "go-kit",
+		},
+		{
+			"Warn", "warn", "gateway-service", "go-kit",
+		},
+		{
+			"Error", "error", "storage-service", "go-kit",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := NewLogger(tc.logLevel, tc.serviceName, tc.loggerName)
+
+			assert.NotNil(t, logger)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds `timestamp` to `go-service` logs!